### PR TITLE
refactor: split flutter_lua_bridge into two API styles

### DIFF
--- a/lib/flutter_lua_bridge.dart
+++ b/lib/flutter_lua_bridge.dart
@@ -3,83 +3,64 @@
 /// Dart 与 Lua 的 FFI 绑定库，支持从源码编译 Lua，
 /// 便于替换 Lua 核心。
 ///
-/// 提供两层 API：
-/// 1. 底层 FFI 绑定 - 直接调用 Lua C API（生成的代码）
-/// 2. 高层封装 - 面向对象的 Dart API（推荐）
+/// 本库提供两种 API 风格：
+///
+/// 1. **原始 C API** (`lua_raw_api.dart`)
+///    - 保持 C 语言命名风格（小写下划线）
+///    - 适合熟悉 Lua C API 的用户
+///    - 直接翻译 C 代码更方便
+///
+/// 2. **Dart 风格 API** (`lua_dart_api.dart`)
+///    - 面向对象的 LuaState 类
+///    - 符合 Dart 命名规范（小驼峰）
+///    - 自动内存管理和异常处理
+///    - 推荐 Dart 开发者使用
+///
+/// 默认导出（向后兼容）：同时导出两套 API
 ///
 /// 使用示例：
 /// ```dart
 /// import 'package:flutter_lua_bridge/flutter_lua_bridge.dart';
 ///
 /// void main() {
-///   // 方式1：使用高层封装（推荐）
-///   LuaState.create().use((lua) {
+///   // 推荐：使用 Dart 风格 API
+///   LuaState.use((lua) {
 ///     lua.openLibs();
 ///     lua.doString('print("Hello from Lua!")');
 ///   });
-///
-///   // 方式2：使用底层 FFI
+///   
+///   // 也可以使用原始 C API
 ///   final L = luaL_newstate();
 ///   luaL_openlibs(L);
-///   luaL_dostring(L, 'print("Hello")'.toPointerChar());
 ///   lua_close(L);
 /// }
 /// ```
-
-// ==================== 核心常量 ====================
-export 'src/core/lua_constants.dart';
-
-// ==================== Lua 状态封装 ====================
-export 'src/core/lua_state.dart';
-
-// ==================== FFI 生成的底层绑定 ====================
 ///
-/// 这些是由 ffigen 自动生成的 FFI 绑定，
-/// 包含完整的 Lua C API。
+/// 或者只导入你需要的风格：
+/// ```dart
+/// // 只使用 Dart 风格
+/// import 'package:flutter_lua_bridge/lua_dart_api.dart';
 ///
-/// 注意：直接使用这些 API 需要手动管理内存和错误处理。
-///
-/// 隐藏与 lua_constants.dart 中重复的常量
-export 'src/gen/flutter_lua_bridge.g.dart'
-    hide LUA_MULTRET, LUA_NOREF, LUA_REFNIL;
+/// // 只使用原始 C 风格
+/// import 'package:flutter_lua_bridge/lua_raw_api.dart';
+/// ```
 
-// ==================== 辅助工具 ====================
-///
-/// 类型转换辅助，包含 String/Pointer<Char> 转换、
-/// LuaState 扩展方法等。
-export 'src/utils/type_convert_helper.dart';
+library flutter_lua_bridge;
 
-// ==================== 兼容旧版本 ====================
-///
-/// 以下导出为兼容旧版本，建议使用新的 LuaState API
-///
+// ==================== 子库导出 ====================
 
-// 类型转换扩展（已移动到 utils）
-export 'src/utils/type_convert_helper.dart'
-    show PointCharX, NativePointCharX, StringPointerHelper, StringBatch;
+/// 原始 C API 导出（C 语言风格）
+/// - 小写下划线命名
+/// - 直接操作指针
+/// - 需要手动管理内存
+export 'lua_raw_api.dart';
 
-// Lua 状态扩展（已移动到 utils）
-export 'src/utils/type_convert_helper.dart' show LuaStateX;
+/// Dart 风格 API 导出（Dart 习惯）
+/// - 小驼峰命名
+/// - 面向对象封装
+/// - 自动内存管理
+export 'lua_dart_api.dart';
 
-// ==================== 已弃用的导出 ====================
-///
-/// 以下文件的内容已整合到新的结构中，
-/// 保留导出以确保向后兼容。
-///
-@Deprecated('使用 LuaState 类或 lua_constants.dart 中的常量')
-export 'src/macro_defines.dart'
-    hide
-        LUA_MULTRET,
-        LUA_NOREF,
-        LUA_REFNIL,
-        lua_pcall,
-        luaL_dostring,
-        lua_tostring,
-        lua_pop,
-        lua_pushcfunction;
-
-@Deprecated('功能已合并到 type_convert_helper.dart')
-export 'src/helper/quick_call_method.dart';
-
-@Deprecated('功能已合并到 type_convert_helper.dart')
-export 'src/helper/type_convert_helper.dart';
+// ==================== 兼容性导出 ====================
+/// 为了保持向后兼容，主库仍然导出所有内容
+/// 新项目建议根据需求导入子库

--- a/lib/lua_dart_api.dart
+++ b/lib/lua_dart_api.dart
@@ -1,0 +1,54 @@
+/// Flutter Lua Bridge - Dart 风格 API 导出
+///
+/// 这个库提供符合 Dart 编码习惯的 API：
+/// 1. 面向对象的 LuaState 类
+/// 2. Dart 命名规范的扩展方法（小驼峰）
+/// 3. 自动内存管理
+/// 4. 异常处理而非返回码
+///
+/// 命名风格符合 Dart 规范：
+/// - `luaState.pcall()` 而不是 `lua_pcall()`
+/// - `luaState.pop()` 而不是 `lua_pop()`
+/// - `luaState.doString()` 而不是 `luaL_dostring()`
+///
+/// 适合 Dart 开发者，代码更简洁、更符合 Dart 习惯。
+///
+/// 使用示例：
+/// ```dart
+/// import 'package:flutter_lua_bridge/lua_dart_api.dart';
+///
+/// void main() {
+///   // 方式1: 使用 use 自动管理生命周期
+///   LuaState.use((lua) {
+///     lua.openLibs();
+///     lua.doString('print("Hello from Lua!")');
+///   });
+///   
+///   // 方式2: 手动管理生命周期
+///   final lua = LuaState.create();
+///   try {
+///     lua.openLibs();
+///     final result = lua.tryDoString('return 1 + 1');
+///     print(result.value); // 2
+///   } finally {
+///     lua.close();
+///   }
+/// }
+/// ```
+
+library flutter_lua_bridge.dart_api;
+
+// ==================== 核心常量 ====================
+/// Lua 常量定义（状态码、类型、GC 操作等）
+export 'src/core/lua_constants.dart';
+
+// ==================== Lua 状态封装 ====================
+/// 面向对象的 LuaState 类
+export 'src/core/lua_state.dart';
+
+// ==================== Dart 风格扩展 ====================
+/// LuaState 指针的 Dart 风格扩展方法
+/// - 小驼峰命名
+/// - 返回 bool 而不是 int
+/// - 自动内存管理
+export 'src/utils/type_convert_helper.dart';

--- a/lib/lua_raw_api.dart
+++ b/lib/lua_raw_api.dart
@@ -1,0 +1,53 @@
+/// Flutter Lua Bridge - 原始 C API 导出
+///
+/// 这个库导出 Lua 的原始 C API，包括：
+/// 1. ffigen 自动生成的 FFI 绑定
+/// 2. 手动实现的 C 语言宏函数
+///
+/// 命名风格保持与 C 语言一致（小写下划线）：
+/// - `lua_pcall` 而不是 `luaPcall`
+/// - `lua_pop` 而不是 `luaPop`
+/// - `luaL_dostring` 而不是 `luaLDoString`
+///
+/// 适合熟悉 Lua C API 的用户，或者需要直接翻译 C 代码的场景。
+///
+/// 使用示例：
+/// ```dart
+/// import 'package:flutter_lua_bridge/lua_raw_api.dart';
+///
+/// void main() {
+///   final L = luaL_newstate();
+///   luaL_openlibs(L);
+///   
+///   final code = 'print("Hello from Lua!")'.toPointerChar();
+///   try {
+///     if (luaL_dostring(L, code) == LUA_OK) {
+///       print('Success');
+///     }
+///   } finally {
+///     calloc.free(code);
+///   }
+///   
+///   lua_close(L);
+/// }
+/// ```
+
+library flutter_lua_bridge.raw_api;
+
+// ==================== FFI 生成的底层绑定 ====================
+/// 自动生成的 FFI 绑定，包含完整的 Lua C API
+export 'src/gen/flutter_lua_bridge.g.dart'
+    hide LUA_MULTRET, LUA_NOREF, LUA_REFNIL;
+
+// ==================== 核心常量 ====================
+/// Lua 常量定义（状态码、类型、GC 操作等）
+export 'src/core/lua_constants.dart';
+
+// ==================== C API 宏函数 ====================
+/// C 语言 Lua API 中的宏和内联函数的 Dart 实现
+export 'src/core/lua_c_api_helpers.dart';
+
+// ==================== 基础类型转换（原始风格） ====================
+/// 字符串和指针之间的基础转换
+export 'src/utils/type_convert_helper.dart'
+    show PointCharX, NativePointCharX, StringPointerHelper, StringBatch;

--- a/lib/src/core/lua_c_api_helpers.dart
+++ b/lib/src/core/lua_c_api_helpers.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: non_constant_identifier_names
+///
+/// Lua C API 辅助函数
+///
+/// 这些函数在 C 语言 Lua API 中是宏或内联函数，
+/// 在 Dart 中需要手动实现。
+///
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import '../gen/flutter_lua_bridge.g.dart';
+
+/// lua_pop 宏: lua_settop(L, -(n)-1)
+///
+/// 从栈中弹出 n 个元素
+void lua_pop(Pointer<lua_State> L, int n) => lua_settop(L, -n - 1);
+
+/// lua_tostring 别名: lua_tolstring(L, idx, NULL)
+///
+/// 将栈中指定索引的值转换为 C 字符串指针
+Pointer<Char> lua_tostring(Pointer<lua_State> L, int idx) =>
+    lua_tolstring(L, idx, nullptr);
+
+/// lua_pcall 别名: lua_pcallk(L, nargs, nresults, errfunc, 0, NULL)
+///
+/// 以保护模式调用 Lua 函数
+int lua_pcall(Pointer<lua_State> L, int nargs, int nresults, int errfunc) =>
+    lua_pcallk(L, nargs, nresults, errfunc, 0, nullptr);
+
+/// luaL_dostring 宏: luaL_loadstring(L, s) || lua_pcall(L, 0, LUA_MULTRET, 0)
+///
+/// 加载并执行 Lua 代码字符串
+int luaL_dostring(Pointer<lua_State> L, Pointer<Char> s) {
+  final status = luaL_loadstring(L, s);
+  if (status != 0) return status;
+  return lua_pcall(L, 0, LUA_MULTRET, 0);
+}

--- a/test/shell.dart
+++ b/test/shell.dart
@@ -1,7 +1,7 @@
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:flutter_lua_bridge/flutter_lua_bridge.dart';
+import 'package:flutter_lua_bridge/lua_raw_api.dart';
 
 /// 模拟 C 语言版本的 Lua Shell
 /// 从标准输入读取 Lua 代码，解释执行后输出结果和异常
@@ -105,7 +105,7 @@ void main(List<String> args) {
 /// 加载并执行 Lua 代码
 /// 对应 luaL_loadstring(L, s) || lua_pcall(L, 0, LUA_MULTRET, 0)
 int _dostring(Pointer<lua_State> L, String code) {
-  final Pointer<Char> codePtr = code.toPointChar();
+  final Pointer<Char> codePtr = code.toPointerChar();
 
   // luaL_loadstring: 加载代码（自动计算长度，使用代码内容作为 chunkname）
   int status = luaL_loadstring(L, codePtr);


### PR DESCRIPTION
- Add lua_raw_api.dart: exports raw C API with original naming (lua_pcall, lua_pop, etc.)
- Add lua_dart_api.dart: exports Dart-style API with camelCase naming (LuaState class)
- Add lua_c_api_helpers.dart: C macro implementations in Dart (lua_pop, lua_pcall, lua_tostring, luaL_dostring)
- Update flutter_lua_bridge.dart to export both APIs for backward compatibility
- Update test/shell.dart to use lua_raw_api.dart

Users can now choose their preferred API style:
- import 'lua_raw_api.dart' for C-style API
- import 'lua_dart_api.dart' for Dart-style API